### PR TITLE
Avoid failing with adblockers

### DIFF
--- a/cover.js
+++ b/cover.js
@@ -68,7 +68,7 @@ cacheJS.on('cacheAdded', function(objAdded) {
 
 if (data_list === null) {
     firebase.initializeApp(firebaseConfig);
-    firebase.analytics();
+    if (firebase.analytics) firebase.analytics();
     const db = firebase.firestore();
 
     data_list = [];


### PR DESCRIPTION
Hi @darensin01, thanks for this project - very nice initiative!

I first noticed that this page was not loading (also after hard refresh and everything), and looked into the issue. I realized that the analytics were not loading because of my adblocker (uBlock Origin), and this causes the page to fail (hangs at 15%):

![Screen Shot 2020-09-19 at 17 48 24](https://user-images.githubusercontent.com/1935696/93671184-16f42880-faa1-11ea-8805-b121e51c6fcc.png)

If you check first whether the `firebase.analytics` method is truthy, then this issue is mitigated.