### PR TITLE
change background-color of nano-pane and nano-scroller

### DIFF
--- a/nanoscroller.css
+++ b/nanoscroller.css
@@ -24,7 +24,7 @@
   display: block;
 }
 .nano > .nano-pane {
-  background : rgba(0,0,0,.25);
+  background : #667373;
   position   : absolute;
   width      : 10px;
   right      : 0;
@@ -41,8 +41,7 @@
   border-radius         : 5px;
 }
 .nano > .nano-pane > .nano-slider {
-  background: #444;
-  background: rgba(0,0,0,.5);
+  background: whitesmoke;
   position              : relative;
   margin                : 0 1px;
   -moz-border-radius    : 3px;


### PR DESCRIPTION
The nano scroller and nano-pane are hardly visible with a black background so I thought it would be good to change its background color to make it more visible.
```
.nano > .nano-pane {
  background : #667373;
```
```
.nano > .nano-pane > .nano-slider {
  background: whitesmoke;
```
Hope you'll merge this to your repo!! :)