### PR TITLE
Fix: Reduce extra padding on mobile view

### DIFF
--- a/styles/cover.css
+++ b/styles/cover.css
@@ -262,5 +262,10 @@ button.close {
     font-size: 3.5rem;
   }
 }
-
+ 
+@media (max-width: 768px) {
+    .cover {
+      padding: 0;
+    }
+}
 .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}


### PR DESCRIPTION
This PR adjusts the .cover padding using a media query for smaller screens.

Result:
- Better use of screen space on mobile
- Reduced unnecessary horizontal padding
- Improved readability

Tested using browser dev tools (mobile view).